### PR TITLE
Propagate undefined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ var object = {
 var cancel = bind(object, "selected", {
     "<-": "source[key]"
 });
-expect(object.selected).toBe(null);
+expect(object.selected).toBe(undefined);
 
 object.key = a;
 expect(object.selected).toBe(10);
@@ -542,7 +542,7 @@ expect(object.selected).toBe(30);
 
 var SortedMap = require("collections/sorted-map");
 object.source = SortedMap();
-expect(object.selected).toBe(30); // no change
+expect(object.selected).toBe(undefined);
 
 object.source.set(b, 40);
 expect(object.selected).toBe(40);

--- a/binders.js
+++ b/binders.js
@@ -7,6 +7,7 @@ exports.makePropertyBinder = makePropertyBinder;
 function makePropertyBinder(observeObject, observeKey) {
     return function (observeValue, source, target, parameters, descriptor, trace) {
         return observeObject(autoCancelPrevious(function (object) {
+            if (!object) return;
             return observeKey(autoCancelPrevious(function (key) {
                 return observeValue(autoCancelPrevious(function (value) {
                     if (descriptor.isActive) {
@@ -30,6 +31,7 @@ exports.makeGetBinder = makeGetBinder;
 function makeGetBinder(observeCollection, observeKey) {
     return function bindGet(observeValue, source, target, parameters, descriptor, trace) {
         return observeCollection(autoCancelPrevious(function replaceCollection(collection) {
+            if (!collection) return;
             return observeKey(autoCancelPrevious(function replaceKey(key) {
                 return observeValue(autoCancelPrevious(function replaceValue(value) {
                     if (descriptor.isActive) {
@@ -53,6 +55,7 @@ exports.makeHasBinder = makeHasBinder;
 function makeHasBinder(observeSet, observeValue) {
     return function (observeHas, source, target, parameters, descriptor, trace) {
         return observeSet(autoCancelPrevious(function (set) {
+            if (!set) return;
             return observeValue(autoCancelPrevious(function (value) {
                 return observeHas(autoCancelPrevious(function (has) {
                     // wait for the initial value to be updated by the
@@ -93,7 +96,13 @@ exports.makeRangeContentBinder = makeRangeContentBinder;
 function makeRangeContentBinder(observeTarget) {
     return function (observeSource, source, target, parameters, descriptor, trace) {
         return observeTarget(autoCancelPrevious(function (target) {
+            if (!target) return;
             return observeSource(autoCancelPrevious(function (source) {
+                if (!source) {
+                    target.clear();
+                    return;
+                }
+
                 function rangeChange(plus, minus, index) {
                     if (isActive(target))
                         return;
@@ -121,7 +130,13 @@ exports.makeMapContentBinder = makeMapContentBinder;
 function makeMapContentBinder(observeTarget) {
     return function (observeSource, source, target, parameters, descriptor, trace) {
         return observeTarget(autoCancelPrevious(function (target) {
+            if (!target) return;
             return observeSource(autoCancelPrevious(function (source) {
+                if (!source) {
+                    target.clear();
+                    return;
+                }
+
                 function mapChange(value, key) {
                     if (descriptor.isActive) {
                         if (trace) {
@@ -162,7 +177,13 @@ exports.makeReversedBinder = makeReversedBinder;
 function makeReversedBinder(observeTarget) {
     return function (observeSource, source, target, parameters, descriptor, trace) {
         return observeTarget(autoCancelPrevious(function (target) {
+            if (!target) return;
             return observeSource(autoCancelPrevious(function (source) {
+                if (!source) {
+                    target.clear();
+                    return;
+                }
+
                 function rangeChange(plus, minus, index) {
                     if (isActive(target))
                         return;

--- a/compute.js
+++ b/compute.js
@@ -14,9 +14,18 @@ function compute(target, targetPath, descriptor) {
     var parameters = descriptor.parameters = descriptor.parameters || source;
     var trace = descriptor.trace;
 
-    var argSyntacies = args.map(parse);
-    var argObservers = argSyntacies.map(compileObserver).map(Observers.makeContentObserver);
-    var argsObserver = Observers.makeContentObserver(
+    var argObservers = args.map(parse).map(function (argSyntax) {
+        if (argSyntax.type === "rangeContent") {
+            var observeArg = compileObserver(argSyntax.args[0]);
+            return Observers.makeRangeContentObserver(observeArg);
+        } else if (argSyntax.type === "mapContent") {
+            var observeArg = compileObserver(argSyntax.args[0]);
+            return Observers.makeMapContentObserver(observeArg);
+        } else {
+            return compileObserver(argSyntax);
+        }
+    });
+    var argsObserver = Observers.makeRangeContentObserver(
         Observers.makeObserversObserver(argObservers)
     );
     var observeSource = Observers.makeComputerObserver(argsObserver, compute, target);

--- a/observers.js
+++ b/observers.js
@@ -50,7 +50,7 @@ function makeConverterObserver(observeValue, convert, thisp) {
     return function (emit, value, parameters, beforeChange) {
         emit = makeUniq(emit);
         return observeValue(autoCancelPrevious(function replaceValue(value) {
-            return emit(convert.call(thisp, value)) || Function.noop;
+            return emit(convert.call(thisp, value));
         }), value, parameters, beforeChange);
     };
 }
@@ -60,7 +60,8 @@ function makeComputerObserver(observeArgs, compute, thisp) {
     return function (emit, value, parameters, beforeChange) {
         emit = makeUniq(emit);
         return observeArgs(autoCancelPrevious(function replaceArgs(args) {
-            return emit(compute.apply(thisp, args)) || Function.noop;
+            if (!args || !args.every(defined)) return;
+            return emit(compute.apply(thisp, args));
         }), value, parameters, beforeChange);
     };
 }
@@ -69,7 +70,10 @@ exports.makePropertyObserver = makePropertyObserver;
 function makePropertyObserver(observeObject, observeKey) {
     return function observeProperty(emit, value, parameters, beforeChange) {
         return observeKey(autoCancelPrevious(function replaceKey(key) {
+            if (key == null) return emit();
             return observeObject(autoCancelPrevious(function replaceObject(object) {
+                if (object == null) return emit();
+
                 var cancel = Function.noop;
                 function propertyChange(value, key, object) {
                     cancel();
@@ -77,6 +81,7 @@ function makePropertyObserver(observeObject, observeKey) {
                 }
                 PropertyChanges.addOwnPropertyChangeListener(object, key, propertyChange, beforeChange);
                 propertyChange(object[key], key, object);
+
                 return once(function cancelPropertyObserver() {
                     cancel();
                     PropertyChanges.removeOwnPropertyChangeListener(object, key, propertyChange, beforeChange);
@@ -90,6 +95,7 @@ exports.makeGetObserver = makeGetObserver;
 function makeGetObserver(observeCollection, observeKey) {
     return function observeMap(emit, value, parameters, beforeChange) {
         return observeCollection(autoCancelPrevious(function replaceCollection(collection) {
+            if (!collection) return emit();
             var equals = collection.contentEquals || Object.equals;
             return observeKey(autoCancelPrevious(function replaceKey(key) {
                 var cancel = Function.noop;
@@ -115,7 +121,7 @@ function makeWithObserver(observeContext, observeExpression) {
     return function observeWith(emit, value, parameters, beforeChange) {
         return observeContext(autoCancelPrevious(function replaceContext(context) {
             return observeExpression(autoCancelPrevious(function replaceValue(value) {
-                return emit(value) || Function.noop;
+                return emit(value);
             }), context, parameters, beforeChange);
         }), value, parameters, beforeChange);
     };
@@ -149,6 +155,7 @@ function makeHasObserver(observeSet, observeValue) {
         emit = makeUniq(emit);
         return observeValue(autoCancelPrevious(function replaceValue(sought) {
             return observeSet(autoCancelPrevious(function replaceSet(set) {
+                if (!set) return emit();
                 return observeRangeChange(set, function rangeChange() {
                     // this could be done incrementally if there were guarantees of
                     // uniqueness, but if there are guarantees of uniqueness, the
@@ -160,14 +167,29 @@ function makeHasObserver(observeSet, observeValue) {
     };
 }
 
-exports.makeContentObserver = makeContentObserver;
-function makeContentObserver(observeCollection) {
+exports.makeRangeContentObserver = makeRangeContentObserver;
+function makeRangeContentObserver(observeCollection) {
     return function observeContent(emit, value, parameters, beforeChange) {
         return observeCollection(autoCancelPrevious(function (collection) {
-            if (!collection.addRangeChangeListener) {
+            if (!collection || !collection.addRangeChangeListener) {
                 return emit(collection);
             } else {
                 return observeRangeChange(collection, function rangeChange() {
+                    return emit(collection);
+                }, beforeChange);
+            }
+        }), value, parameters, beforeChange);
+    };
+}
+
+exports.makeMapContentObserver = makeMapContentObserver;
+function makeMapContentObserver(observeCollection) {
+    return function observeContent(emit, value, parameters, beforeChange) {
+        return observeCollection(autoCancelPrevious(function (collection) {
+            if (!collection || !collection.addMapChangeListener) {
+                return emit(collection);
+            } else {
+                return observeMapChange(collection, function rangeChange() {
                     return emit(collection);
                 }, beforeChange);
             }
@@ -179,7 +201,9 @@ exports.makeMapFunctionObserver = makeNonReplacing(makeReplacingMapFunctionObser
 function makeReplacingMapFunctionObserver(observeCollection, observeRelation) {
     return function (emit, value, parameters, beforeChange) {
         return observeRelation(autoCancelPrevious(function replaceRelation(relation) {
+            if (!relation) return emit();
             return observeCollection(autoCancelPrevious(function replaceMapInput(input) {
+                if (!input) return emit();
                 var output = [];
                 var cancel = observeRangeChange(input, function rangeChange(plus, minus, index) {
                     output.swap(index, minus.length, plus.map(relation));
@@ -195,6 +219,8 @@ var makeMapBlockObserver = exports.makeMapBlockObserver = makeNonReplacing(makeR
 function makeReplacingMapBlockObserver(observeArray, observeRelation) {
     return function observeMap(emit, value, parameters, beforeChange) {
         return observeArray(autoCancelPrevious(function replaceMapInput(input) {
+            if (!input) return emit();
+
             var output = [];
             var indexRefs = [];
             var cancelers = [];
@@ -247,6 +273,8 @@ function makeReplacingFilterBlockObserver(observeArray, observePredicate) {
     var observePredicates = makeReplacingMapBlockObserver(observeArray, observePredicate);
     return function observeFilter(emit, value, parameters, beforeChange) {
         return observePredicates(autoCancelPrevious(function (predicates, input) {
+            if (!input) return emit();
+
             var output = [];
             var cancelers = [];
             var cumulativeLengths = [0];
@@ -312,6 +340,8 @@ function makeReplacingSortedBlockObserver(observeCollection, observeRelation) {
     var observeMapPack = makeReplacingMapBlockObserver(observeCollection, observePack);
     var observeSort = function (emit, value, parameters, beforeChange) {
         return observeMapPack(autoCancelPrevious(function (input) {
+            if (!input) return emit();
+
             var output = [];
             var sorted = SortedArray(
                 output,
@@ -356,15 +386,21 @@ exports.makeOperatorObserverMaker = makeOperatorObserverMaker;
 function makeOperatorObserverMaker(operator) {
     return function makeOperatorObserver(/*...observers*/) {
         var observeOperands = makeObserversObserver(Array.prototype.slice.call(arguments));
-        var observeOperandChanges = makeContentObserver(observeOperands);
+        var observeOperandChanges = makeRangeContentObserver(observeOperands);
         return function observeOperator(emit, value, parameters, beforeChange) {
-            return observeOperandChanges(function (operands) {
+            return observeOperandChanges(autoCancelPrevious(function (operands) {
                 if (operands.every(defined)) {
-                    return emit(operator.apply(void 0, operands)) || Function.noop;
+                    return emit(operator.apply(void 0, operands));
+                } else {
+                    return emit()
                 }
-            }, value, parameters, beforeChange);
+            }), value, parameters, beforeChange);
         };
     };
+}
+
+function defined(x) {
+    return x != null;
 }
 
 exports.makeTupleObserver = makeTupleObserver;
@@ -378,6 +414,9 @@ exports.makeObserversObserver = makeObserversObserver;
 function makeObserversObserver(observers) {
     return function observeObservers(emit, value, parameters, beforeChange) {
         var output = Array(observers.length);
+        for (var i = 0; i < observers.length; i++) {
+            output[i] = undefined; // pevent sparse/holes
+        }
         var cancelers = observers.map(function observeObserver(observe, index) {
             return observe(function replaceValue(value) {
                 output.set(index, value);
@@ -399,6 +438,8 @@ exports.makeReversedObserver = makeNonReplacing(makeReplacingReversedObserver);
 function makeReplacingReversedObserver(observeArray) {
     return function observeReversed(emit, value, parameters, beforeChange) {
         return observeArray(autoCancelPrevious(function (input) {
+            if (!input) return emit();
+
             var output = [];
             function rangeChange(plus, minus, index) {
                 var reflected = output.length - index - minus.length;
@@ -418,9 +459,12 @@ exports.makeViewObserver = makeNonReplacing(makeReplacingViewObserver);
 function makeReplacingViewObserver(observeInput, observeStart, observeLength) {
     return function observeView(emit, value, parameters, beforeChange) {
         return observeInput(autoCancelPrevious(function (input) {
+            if (!input) return emit();
             return observeLength(autoCancelPrevious(function (length) {
+                if (length == null) return emit();
                 var previousStart;
                 return observeStart(autoCancelPrevious(function (start) {
+                    if (start == null) return emit();
                     var output = [];
                     function rangeChange(plus, minus, index) {
                         var diff = plus.length - minus.length;
@@ -464,6 +508,8 @@ exports.makeFlattenObserver = makeNonReplacing(makeReplacingFlattenObserver);
 function makeReplacingFlattenObserver(observeArray) {
     return function (emit, value, parameters, beforeChange) {
         return observeArray(autoCancelPrevious(function (input) {
+            if (!input) return emit();
+
             var output = [];
             var cancelers = [];
             var cumulativeLengths = [0];
@@ -524,6 +570,8 @@ exports.makeEnumerationObserver = makeNonReplacing(makeReplacingEnumerationObser
 function makeReplacingEnumerationObserver(observeArray) {
     return function (emit, value, parameters, beforeChange) {
         return observeArray(autoCancelPrevious(function replaceArray(input) {
+            if (!input) return emit();
+
             var output = [];
             function update(index) {
                 for (; index < output.length; index++) {
@@ -564,12 +612,16 @@ function makeNonReplacing(wrapped) {
         return function (emit, value, parameters, beforeChange) {
             var output = [];
             var cancelObserver = observe(autoCancelPrevious(function (input) {
-                output.swap(0, output.length, input);
-                function rangeChange(plus, minus, index) {
-                    output.swap(index, minus.length, plus);
+                if (!input) {
+                    output.clear();
+                } else {
+                    output.swap(0, output.length, input);
+                    function rangeChange(plus, minus, index) {
+                        output.swap(index, minus.length, plus);
+                    }
+                    // TODO fix problem that this would get called twice on replacement
+                    return once(input.addRangeChangeListener(rangeChange, beforeChange));
                 }
-                // TODO fix problem that this would get called twice on replacement
-                return once(input.addRangeChangeListener(rangeChange, beforeChange));
             }), value, parameters, beforeChange);
             var cancel = emit(output) || Function.noop;
             return once(function cancelNonReplacingObserver() {
@@ -605,12 +657,13 @@ function makeCollectionObserverMaker(setup) {
     return function (observeCollection) {
         return function (emit, value, parameters, beforeChange) {
             emit = makeUniq(emit);
-            return observeCollection(function (collection) {
+            return observeCollection(autoCancelPrevious(function (collection) {
+                if (!collection) return emit();
                 var rangeChange = setup(collection, emit);
                 return observeRangeChange(collection, function (plus, minus, index) {
                     return emit(rangeChange(plus, minus, index));
                 });
-            }, value, parameters, beforeChange);
+            }), value, parameters, beforeChange);
         };
     };
 }
@@ -626,6 +679,20 @@ function observeRangeChange(collection, emit, beforeChange) {
     return once(function cancelRangeObserver() {
         cancelChild();
         cancelRangeChange();
+    });
+}
+
+function observeMapChange(collection, emit, beforeChange) {
+    var cancelChild = Function.noop;
+    function mapChange() {
+        cancelChild();
+        cancelChild = emit(collection) || Function.noop;
+    }
+    mapChange();
+    var cancelMapChange = collection.addMapChangeListener(mapChange, beforeChange);
+    return once(function cancelMapObserver() {
+        cancelChild();
+        cancelMapChange();
     });
 }
 
@@ -651,10 +718,7 @@ function autoCancelPrevious(emit) {
     var cancelPrevious = Function.noop;
     return function cancelPreviousAndReplace(value) {
         cancelPrevious();
-        cancelPrevious = Function.noop;
-        if (value != null) {
-            cancelPrevious = emit.apply(this, arguments) || Function.noop;
-        }
+        cancelPrevious = emit.apply(this, arguments) || Function.noop;
         return function cancelLast() {
             cancelPrevious();
         };
@@ -673,9 +737,5 @@ function once(callback) {
         //done = new Error("First call:");
         return callback.apply(this, arguments);
     }
-}
-
-function defined(x) {
-    return x != null;
 }
 

--- a/spec/bind-spec.js
+++ b/spec/bind-spec.js
@@ -200,7 +200,7 @@ describe("bind", function () {
 
     describe("has <-", function () {
         var object = {set: [1, 2, 3], sought: 2};
-        var cancel = bind(object, "set.has(sought)", {"<->": "has"});
+        var cancel = bind(object, "has", {"<->": "set.has(sought)"});
 
         expect(object.set.slice()).toEqual([1, 2, 3]);
         object.has = false;

--- a/spec/bindings-spec.js
+++ b/spec/bindings-spec.js
@@ -229,5 +229,16 @@ describe("bindings", function () {
         expect(object.someEqualZero).toBe(false);
     });
 
+    it("should observe undefined when an array retreats behind an observed index", function () {
+        var object = Bindings.defineBindings({
+            bar: ["a", "b", "c"]
+        }, {
+            foo: {"<-": "bar.2"}
+        });
+        object.bar.pop();
+        expect(object.foo).toBe(undefined);
+        expect(object.bar.length).toBe(2);
+    });
+
 });
 

--- a/spec/compute-spec.js
+++ b/spec/compute-spec.js
@@ -54,18 +54,18 @@ describe("compute", function () {
     });
 
     it("content changes", function () {
-        var object = {a: [1, 2, 3], offset: 0};
+        var object = {values: [1, 2, 3], offset: 0};
         var cancel = compute(object, "sum", {
-            args: ["a", "offset"],
+            args: ["values.*", "offset"],
             compute: function (values, offset) {
-                return values.map(function (n) {
-                    return n + offset;
+                return values.map(function (value) {
+                    return value + offset;
                 }).sum();
             }
         });
 
         expect(object.sum).toEqual(6);
-        object.a.push(4);
+        object.values.push(4);
         expect(object.sum).toEqual(10);
 
         object.offset = 1;

--- a/spec/evaluate-with-observe-spec.js
+++ b/spec/evaluate-with-observe-spec.js
@@ -12,7 +12,11 @@ describe("observe", function () {
                 var observe = compile(syntax);
                 var output;
                 var cancel = observe(function (initial) {
-                    output = initial;
+                    if (Array.isArray(initial)) {
+                        output = initial.slice(); // to ditch observable prototype
+                    } else {
+                        output = initial;
+                    }
                 }, test.input, test.parameters);
                 cancel();
                 expect(output).toEqual(test.output);

--- a/spec/observe-filter-spec.js
+++ b/spec/observe-filter-spec.js
@@ -6,7 +6,7 @@ describe("observe filter", function () {
     it("should work", function () {
         var input = [1, 2, 3, 4, 5, 6, 7, 8, 9];
         var output;
-        var cancel = O.makeContentObserver(O.makeFilterBlockObserver(
+        var cancel = O.makeRangeContentObserver(O.makeFilterBlockObserver(
             O.makeLiteralObserver(input),
             O.makeRelationObserver(function (value) {
                 return !(value & 1);

--- a/spec/readme-spec.js
+++ b/spec/readme-spec.js
@@ -321,7 +321,7 @@ describe("Tutorial", function () {
         var cancel = bind(object, "selected", {
             "<-": "source[key]"
         });
-        expect(object.selected).toBe(null);
+        expect(object.selected).toBe(undefined);
 
         object.key = a;
         expect(object.selected).toBe(10);
@@ -334,7 +334,7 @@ describe("Tutorial", function () {
 
         var SortedMap = require("collections/sorted-map");
         object.source = SortedMap();
-        expect(object.selected).toBe(30); // no change
+        expect(object.selected).toBe(undefined);
 
         object.source.set(b, 40);
         expect(object.selected).toBe(40);


### PR DESCRIPTION
This case motivates a radical change in the way null and undefined are
propagated.

```
var object = Bindings.defineBindings({
    bar: ["a", "b", "c"]
}, {
    foo: {"<-": "bar.2"}
});
object.bar.pop();
expect(object.foo).toBe(undefined);
expect(object.bar.length).toBe(2);
```

Hitherto, undefined values were not propagated at all.  They are now
propagated selectively, and every observer and binder must therefore
test for an undefined value and propagate appropriately.

This change also alters computed properties such that observed
collections must use range and map change notation if they wish to
recompute every time the content changes.
