### PR TITLE
Support polymorphic Scope nest method

### DIFF
--- a/assign.js
+++ b/assign.js
@@ -3,6 +3,8 @@ var parse = require("./parse");
 var compile = require("./compile-assigner");
 var Scope = require("./scope");
 
+// TODO deprecate.  this is too easy to implement better at other layers,
+// depending on scopes.
 module.exports = assign;
 function assign(target, path, value, parameters, document, components) {
     var syntax;
@@ -12,6 +14,10 @@ function assign(target, path, value, parameters, document, components) {
         syntax = path;
     }
     var assign = compile(syntax);
-    return assign(value, new Scope(target, null, parameters, document, components));
+    var scope = new Scope(target);
+    scope.parameters = parameters;
+    scope.document = document;
+    scope.components = components;
+    return assign(value, scope);
 }
 

--- a/bind.js
+++ b/bind.js
@@ -23,8 +23,17 @@ function bind(target, targetPath, descriptor) {
     var components = descriptor.components;
     var trace = descriptor.trace;
 
-    var sourceScope = descriptor.sourceScope = new Scope(source, null, parameters, document, components);
-    var targetScope = descriptor.targetScope = new Scope(target, null, parameters, document, components);
+    // TODO: consider the possibility that source and target have intrinsic
+    // scope properties
+
+    var sourceScope = descriptor.sourceScope = new Scope(source);
+    sourceScope.parameters = parameters;
+    sourceScope.document = document;
+    sourceScope.components = components;
+    var targetScope = descriptor.targetScope = new Scope(target);
+    targetScope.parameters = parameters;
+    targetScope.document = document;
+    targetScope.components = components;
 
     // promote convert and revert from a converter object up to the descriptor
     if (descriptor.converter) {

--- a/binders.js
+++ b/binders.js
@@ -142,7 +142,7 @@ function makeEveryBlockBinder(observeCollection, bindCondition, observeValue) {
                 var cancelers = [];
                 function rangeChange(plus, minus, index) {
                     cancelers.swap(index, minus.length, plus.map(function (value, offset) {
-                        var scope = Scope.nest(target, value);
+                        var scope = target.nest(value);
                         return bindCondition(observeValue, scope, scope, descriptor, trace);
                     }));
                 }

--- a/compile-assigner.js
+++ b/compile-assigner.js
@@ -182,7 +182,7 @@ compile.semantics = {
                     var collection = evaluateCollection(scope);
                     var effect = evaluateEffect(scope);
                     collection.forEach(function (content) {
-                        assignCondition(effect, Scope.nest(scope, content));
+                        assignCondition(effect, scope.nest(content));
                     });
                 }
             };

--- a/compile-evaluator.js
+++ b/compile-evaluator.js
@@ -74,7 +74,7 @@ var argCompilers = {
         return function (scope) {
             return evaluateCollection(scope)
             .map(function (value) {
-                return evaluateRelation(Scope.nest(scope, value));
+                return evaluateRelation(scope.nest(value));
             });
         };
     },
@@ -83,7 +83,7 @@ var argCompilers = {
         return function (scope) {
             return evaluateCollection(scope)
             .filter(function (value) {
-                return evaluatePredicate(Scope.nest(scope, value));
+                return evaluatePredicate(scope.nest(value));
             });
         };
     },
@@ -92,7 +92,7 @@ var argCompilers = {
         return function (scope) {
             return evaluateCollection(scope)
             .some(function (value) {
-                return evaluatePredicate(Scope.nest(scope, value));
+                return evaluatePredicate(scope.nest(value));
             });
         };
     },
@@ -101,7 +101,7 @@ var argCompilers = {
         return function (scope) {
             return evaluateCollection(scope)
             .every(function (value) {
-                return evaluatePredicate(Scope.nest(scope, value));
+                return evaluatePredicate(scope.nest(value));
             });
         };
     },
@@ -110,7 +110,7 @@ var argCompilers = {
         return function (scope) {
             return evaluateCollection(scope)
             .sorted(Function.by(function (value) {
-                return evaluateRelation(Scope.nest(scope, value));
+                return evaluateRelation(scope.nest(value));
             }));
         };
     },
@@ -118,7 +118,7 @@ var argCompilers = {
     sortedSetBlock: function (evaluateCollection, evaluateRelation) {
         return function (scope) {
             function map(x) {
-                return evaluateRelation(Scope.nest(scope, x));
+                return evaluateRelation(scope.nest(x));
             }
             function contentCompare(x, y) {
                 return Object.compare(map(x), map(y));
@@ -138,7 +138,7 @@ var argCompilers = {
         return function (scope) {
             return evaluateCollection(scope)
             .group(function (value) {
-                return evaluateRelation(Scope.nest(scope, value));
+                return evaluateRelation(scope.nest(value));
             });
         };
     },
@@ -147,7 +147,7 @@ var argCompilers = {
         return function (scope) {
             return new Map(evaluateCollection(scope)
             .group(function (value) {
-                return evaluateRelation(Scope.nest(scope, value));
+                return evaluateRelation(scope.nest(value));
             }));
         };
     },
@@ -156,7 +156,7 @@ var argCompilers = {
         return function (scope) {
             return evaluateCollection(scope)
             .min(Function.by(function (value) {
-                return evaluateRelation(Scope.nest(scope, value));
+                return evaluateRelation(scope.nest(value));
             }))
         };
     },
@@ -165,7 +165,7 @@ var argCompilers = {
         return function (scope) {
             return evaluateCollection(scope)
             .max(Function.by(function (value) {
-                return evaluateRelation(Scope.nest(scope, value));
+                return evaluateRelation(scope.nest(value));
             }))
         };
     },
@@ -178,7 +178,7 @@ var argCompilers = {
 
     "with": function (evaluateContext, evaluateExpression) {
         return function (scope) {
-            return evaluateExpression(Scope.nest(scope, evaluateContext(scope)));
+            return evaluateExpression(scope.nest(evaluateContext(scope)));
         };
     },
 
@@ -236,7 +236,7 @@ var argCompilers = {
             try {
                 var syntax = parse(path);
                 var evaluate = compile(syntax);
-                return evaluate(Scope.nest(scope, value));
+                return evaluate(scope.nest(value));
             } catch (exception) {
             }
         }

--- a/compute.js
+++ b/compute.js
@@ -16,8 +16,18 @@ function compute(target, targetPath, descriptor) {
     var document = descriptor.document;
     var components = descriptor.components;
     var trace = descriptor.trace;
-    var sourceScope = descriptor.sourceScope = new Scope(source, null, parameters, document, components);
-    var targetScope = descriptor.targetScope = new Scope(target, null, parameters, document, components);
+
+    // TODO consider the possibility that source and target have intrinsic
+    // scope properties
+    //
+    var sourceScope = descriptor.sourceScope = new Scope(source);
+    sourceScope.parameters = parameters;
+    sourceScope.document = document;
+    sourceScope.components = components;
+    var targetScope = descriptor.targetScope = new Scope(target);
+    targetScope.parameters = parameters;
+    targetScope.document = document;
+    targetScope.components = components;
 
     var argObservers = args.map(function (arg) {
         return parse(arg);

--- a/evaluate.js
+++ b/evaluate.js
@@ -3,6 +3,7 @@ var parse = require("./parse");
 var compile = require("./compile-evaluator");
 var Scope = require("./scope");
 
+// TODO deprecate: this can be done much better with a Scope API
 module.exports = evaluate;
 function evaluate(path, value, parameters, document, components) {
     var syntax;
@@ -12,6 +13,10 @@ function evaluate(path, value, parameters, document, components) {
         syntax = path;
     }
     var evaluate = compile(syntax);
-    return evaluate(new Scope(value, null, parameters, document, components));
+    var scope = new Scope(value);
+    scope.parameters = parameters;
+    scope.document = document;
+    scope.components = components;
+    return evaluate(scope);
 }
 

--- a/observe.js
+++ b/observe.js
@@ -22,15 +22,14 @@ function observe(source, expression, descriptorOrFunction) {
     var components = descriptor.components;
     var beforeChange = descriptor.beforeChange;
     var contentChange = descriptor.contentChange;
-    var sourceScope = new Scope(
-        source,
-        null,
-        parameters,
-        document,
-        components,
-        beforeChange
-    );
 
+    // TODO consider the possibility that source has an intrinsic scope
+    // property
+    var sourceScope = new Scope(source);
+    sourceScope.parameters = parameters;
+    sourceScope.document = document;
+    sourceScope.components = components;
+    sourceScope.beforeChange = beforeChange;
 
     var syntax = parse(expression);
     var observe = compile(syntax);

--- a/observers.js
+++ b/observers.js
@@ -390,7 +390,7 @@ function makeReplacingMapBlockObserver(observeCollection, observeRelation) {
                             // does not dispatch changes.
                             initial[offset] = value;
                         }
-                    }), Scope.nest(scope, value));
+                    }), scope.nest(value));
                 })));
                 initialized = true;
                 output.swap(index, minus.length, initial);
@@ -1219,7 +1219,7 @@ function makeToMapObserver(observeObject) {
                         });
                     }
                     return observeRangeChange(entries, rangeChange, scope);
-                }), Scope.nest(scope, object));
+                }), scope.nest(object));
             } else if (object.addMapChangeListener) { // map reflection
                 function mapChange(value, key) {
                     if (value === undefined) {
@@ -1268,7 +1268,7 @@ var observeUniqueEntries = makeMapBlockObserver(
 exports.makeParentObserver = makeParentObserver;
 function makeParentObserver(observeExpression) {
     return function observeParentScope(emit, scope) {
-        return observeExpression(emit, scope.parent || new Scope());
+        return observeExpression(emit, scope.parent || scope.nest());
     };
 }
 
@@ -1310,7 +1310,7 @@ function makeExpressionObserver(observeInput, observeExpression) {
                 return emit();
             }
             return observeInput(autoCancelPrevious(function replaceInput(input) {
-                return observeOutput(emit, Scope.nest(scope, input));
+                return observeOutput(emit, scope.nest(input));
             }), scope);
         }), scope);
     };
@@ -1322,7 +1322,7 @@ function makeWithObserver(observeInput, observeExpression) {
         return observeInput(autoCancelPrevious(function replaceInput(input) {
             return observeExpression(autoCancelPrevious(function replaceValue(value) {
                 return emit(value);
-            }), Scope.nest(scope, input));
+            }), scope.nest(input));
         }), scope);
     };
 }

--- a/scope.js
+++ b/scope.js
@@ -1,23 +1,14 @@
 
 module.exports = Scope;
-function Scope(value, parent, parameters, document, components, beforeChange) {
+function Scope(value) {
+    this.parent = null;
     this.value = value;
-    this.parent = parent;
-    this.parameters = parameters;
-    this.document = document;
-    this.components = components;
-    this.beforeChange = beforeChange;
 }
 
-Scope.nest = function (scope, value) {
-    scope = scope || new Scope();
-    return new Scope(
-        value,
-        scope,
-        scope.parameters,
-        scope.document,
-        scope.components,
-        scope.beforeChange
-    );
+Scope.prototype.nest = function (value) {
+    var child = Object.create(this);
+    child.value = value;
+    child.parent = this;
+    return child;
 };
 

--- a/spec/evaluate-spec.js
+++ b/spec/evaluate-spec.js
@@ -1,7 +1,6 @@
 
 var parse = require("../parse");
 var evaluate = require("../evaluate");
-var Scope = require("../scope");
 var cases = require("./evaluate");
 
 describe("evaluate", function () {

--- a/spec/evaluate-with-observe-spec.js
+++ b/spec/evaluate-with-observe-spec.js
@@ -13,15 +13,13 @@ describe("observe", function () {
                 var syntax = parse(test.path);
                 var observe = compile(syntax);
                 var output;
+                var scope = new Scope(test.input);
+                scope.parameters = test.parameters;
+                scope.document = test.document;
+                scope.components = test.components;
                 var cancel = observe(function (initial) {
                     output = initial;
-                }, new Scope(
-                    test.input,
-                    null,
-                    test.parameters,
-                    test.document,
-                    test.components
-                ));
+                }, scope);
                 cancel();
                 if (Array.isArray(output)) {
                     output = output.slice(); // to ditch observable prototype


### PR DESCRIPTION
Revisits the Scope implementation and nesting.  Scopes should be nested
with a method, which can in turn be overridden.  Scope should inherit
their properties when nesting, so they do not have to be passed forward
to nest.  Thus, the root scope can be extended to the advantage of all
child scopes.
