### PR TITLE
Restrict property binder domain to values

### DIFF
--- a/observers.js
+++ b/observers.js
@@ -85,7 +85,7 @@ exports.makePropertyObserver = makePropertyObserver;
 function makePropertyObserver(observeObject, observeKey) {
     return function observeProperty(emit, scope) {
         return observeKey(autoCancelPrevious(function replaceKey(key) {
-            if (key == null) return emit();
+            if (typeof key !== "string" && typeof key !== "number") return emit();
             return observeObject(autoCancelPrevious(function replaceObject(object) {
                 if (object == null) return emit();
                 if (object.observeProperty) {


### PR DESCRIPTION
Specifically, numbers and strings.  Previously, any non-null value would
be coerced to a string for the purpose of binding the property.  This
should avoid bugs when there are ephemeral type changes, which
thankfully have not yet been encountered in this case.
