### PR TITLE
Add failing specs for view()

### DIFF
--- a/spec/view-spec.js
+++ b/spec/view-spec.js
@@ -37,5 +37,17 @@ describe("view", function () {
         object.array.push(12);
         expect(object.view).toEqual([6, 8, 10]);
     });
+
+    it("uses array.length - start if length is ommitted", function () {
+        Bindings.defineBindings(object, {
+            view: {"<-": "array.view(2)"}
+        });
+
+        expect(object.view).toEqual([6, 8]);
+        object.array.push(10);
+        expect(object.view).toEqual([6, 8, 10]);
+        object.array.push(12, 14, 16);
+        expect(object.view).toEqual([6, 8, 10, 12, 14, 16]);
+    });
 });
 


### PR DESCRIPTION
- Basic passing spec
- Failing spec when `start` is 0
- Failing spec for `length` longer than array
- (Second commit) Failing spec for omitting `length` defaulting to the rest of the array. Would be nice to have, but if it's not something you want to support I can remove that commit.
