### PR TITLE
Remove need for once()

### DIFF
--- a/binders.js
+++ b/binders.js
@@ -2,7 +2,6 @@
 var Scope = require("./scope");
 var Observers = require("./observers");
 var autoCancelPrevious = Observers.autoCancelPrevious;
-var once = Observers.once;
 var observeRangeChange = Observers.observeRangeChange;
 var cancelEach = Observers.cancelEach;
 var makeNotObserver = Observers.makeNotObserver;
@@ -272,9 +271,9 @@ function makeRangeContentBinder(observeTarget, bindTarget) {
 
                 source.addRangeChangeListener(rangeContentSourceRangeChange);
                 rangeContentSourceRangeChange(Array.from(source), Array.from(target), 0);
-                return once(function cancelRangeContentBinding() {
+                return function cancelRangeContentBinding() {
                     source.removeRangeChangeListener(rangeContentSourceRangeChange);
-                });
+                };
             }), sourceScope);
         }), targetScope);
     };
@@ -344,9 +343,9 @@ function makeReversedBinder(observeTarget) {
                 }
                 source.addRangeChangeListener(rangeChange);
                 rangeChange(source, target, 0);
-                return once(function cancelReversedBinding() {
+                return function cancelReversedBinding() {
                     source.removeRangeChangeListener(rangeChange);
-                });
+                };
             }), source);
         }), target);
     };

--- a/observe.js
+++ b/observe.js
@@ -46,9 +46,9 @@ function observe(source, expression, descriptorOrFunction) {
             return descriptor.change.apply(source, arguments);
         } else if (typeof contentChange === "function") {
             value.addRangeChangeListener(contentChange);
-            return Observers.once(function () {
+            return function () {
                 value.removeRangeChangeListener(contentChange);
-            });
+            };
         }
     }), sourceScope);
 }

--- a/observers.js
+++ b/observers.js
@@ -70,7 +70,7 @@ function observeProperty(object, key, emit, scope) {
         scope.beforeChange
     );
     propertyChange(object[key], key, object);
-    return once(function cancelPropertyObserver() {
+    return function cancelPropertyObserver() {
         cancel();
         PropertyChanges.removeOwnPropertyChangeListener(
             object,
@@ -78,7 +78,7 @@ function observeProperty(object, key, emit, scope) {
             propertyChange,
             scope.beforeChange
         );
-    });
+    };
 }
 
 exports.makePropertyObserver = makePropertyObserver;
@@ -112,10 +112,10 @@ function observeGet(collection, key, emit, scope) {
     }
     mapChange(collection.get(key), key, collection);
     collection.addMapChangeListener(mapChange, scope.beforeChange);
-    return once(function cancelMapObserver() {
+    return function cancelMapObserver() {
         cancel();
         collection.removeMapChangeListener(mapChange);
-    });
+    };
 }
 
 exports.makeGetObserver = makeGetObserver;
@@ -173,10 +173,10 @@ function makeObserversObserver(observers) {
             }, scope);
         })
         var cancel = emit(output) || Function.noop;
-        return once(function cancelObserversObserver() {
+        return function cancelObserversObserver() {
             cancel();
             cancelEach(cancelers);
-        });
+        };
     };
 }
 
@@ -401,11 +401,11 @@ function makeReplacingMapBlockObserver(observeCollection, observeRelation) {
             // mapping observer, utilized by filter observers
             var cancel = emit(output, input) || Function.noop;
 
-            return once(function cancelMapObserver() {
+            return function cancelMapObserver() {
                 cancel();
                 cancelEach(cancelers);
                 cancelRangeChange();
-            });
+            };
         }), scope);
     };
 }
@@ -450,11 +450,11 @@ function makeReplacingFilterBlockObserver(observeCollection, observePredicate) {
 
             var cancelRangeChange = observeRangeChange(predicates, rangeChange, scope);
             var cancel = emit(output) || Function.noop;
-            return once(function cancelFilterObserver() {
+            return function cancelFilterObserver() {
                 cancel();
                 cancelEach(cancelers);
                 cancelRangeChange();
-            });
+            };
 
         }), scope);
     };
@@ -559,10 +559,10 @@ function makeReplacingReversedObserver(observeArray) {
             };
             var cancelRangeChange = observeRangeChange(input, rangeChange, scope);
             var cancel = emit(output);
-            return once(function cancelReversedObserver() {
+            return function cancelReversedObserver() {
                 cancel();
                 cancelRangeChange();
-            });
+            };
         }), scope);
     };
 }
@@ -625,11 +625,11 @@ function makeReplacingFlattenObserver(observeArray) {
             var cancelRangeChange = observeRangeChange(input, rangeChange, scope);
             var cancel = emit(output) || Function.noop;
 
-            return once(function cancelFlattenObserver() {
+            return function cancelFlattenObserver() {
                 cancel();
                 cancelEach(cancelers);
                 cancelRangeChange();
-            });
+            };
         }), scope);
     };
 }
@@ -853,10 +853,10 @@ function makeReplacingViewObserver(observeInput, observeStart, observeLength) {
                     }
                     var cancelRangeChange = observeRangeChange(input, rangeChange, scope);
                     var cancel = emit(output) || Function.noop;
-                    return once(function cancelViewObserver() {
+                    return function cancelViewObserver() {
                         cancel();
                         cancelRangeChange();
-                    });
+                    };
                 }), scope);
             }), scope);
         }), scope);
@@ -1007,10 +1007,10 @@ function observeRangeChange(collection, emit, scope) {
         rangeChange,
         scope.beforeChange
     );
-    return once(function cancelRangeObserver() {
+    return function cancelRangeObserver() {
         cancelChild();
         cancelRangeChange();
-    });
+    };
 }
 
 exports.makeLastObserver = makeLastObserver;
@@ -1125,12 +1125,12 @@ function observeMapChange(collection, emit, scope) {
     }
     collection.forEach(mapChange);
     var cancelMapChange = collection.addMapChangeListener(mapChange, scope.beforeChange);
-    return once(function cancelMapObserver() {
+    return function cancelMapObserver() {
         cancelers.forEach(function (cancel) {
             cancel();
         });
         cancelMapChange();
-    });
+    };
 }
 
 var makeEntriesObserver = exports.makeEntriesObserver = makeNonReplacing(makeReplacingEntriesObserver);
@@ -1166,10 +1166,10 @@ function observeEntries(collection, emit, scope) {
         }
     }
     var cancelMapChange = observeMapChange(collection, mapChange, scope) || Function.noop;
-    return once(function cancelObserveEntries() {
+    return function cancelObserveEntries() {
         cancel();
         cancelMapChange();
-    });
+    };
 }
 
 exports.makeKeysObserver = makeKeysObserver;
@@ -1358,14 +1358,14 @@ function makeNonReplacing(wrapped) {
                         rangeChange,
                         scope.beforeChange
                     );
-                    return once(cancelRangeChange);
+                    return cancelRangeChange;
                 }
             }), scope);
             var cancel = emit(output) || Function.noop;
-            return once(function cancelNonReplacingObserver() {
+            return function cancelNonReplacingObserver() {
                 cancelObserver();
                 cancel();
-            });
+            };
         };
     };
 }
@@ -1404,21 +1404,8 @@ function autoCancelPrevious(emit) {
         cancelPrevious = emit.apply(this, arguments) || Function.noop;
         return function cancelObserver() {
             cancelPrevious();
+            cancelPrevious = Function.noop;
         };
     };
-}
-
-exports.once = once;
-function once(callback) {
-    var done;
-    return function once() {
-        if (done) {
-            return Function.noop; // TODO fix bugs that make this sensitive
-            //throw new Error("Redundant call: " + callback + " " + done.stack + "\nSecond call:");
-        }
-        done = true;
-        //done = new Error("First call:");
-        return callback.apply(this, arguments);
-    }
 }
 


### PR DESCRIPTION
**tl;dr; [autoCancelPrevious should not allow its observer to be replaced after it is cancelled](#discussion_r6577068).** There is a problem upstream with the propertyObserver that allows this to happen, which I can't diagnose. We may want to hold off this merge and fix there.

I spent some time tracing down sources of multiple calls of functions passed to once(). I discovered that all of the ones caused by the current test suite boil down to replacing parent objects that have property observers on them.

```
var test = Bindings.defineBindings({
  a: []
}, {
  "b": {"<-": "a.0"}
}
test.a[0] = 2; // no problem
test.a = [] // kaboom!
```

The property change observer on ".0" has its cancel callback called, and then later in the same call-stack its replace callback is called. Disallowing this in autoCancelPrevious removed all cases of functions passed to once being called more than once.
