### PR TITLE
Add time/space benchmarks

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,12 @@
   },
   "devDependencies": {
     "jasmine-node": "1.x.x",
-    "pegjs": "git://github.com/dmajda/pegjs.git"
+    "pegjs": "git://github.com/dmajda/pegjs.git",
+    "memwatch": "~0.2.2"
   },
   "scripts": {
     "test": "jasmine-node spec",
-    "build-parser": "pegjs --allowed-start-rules expression,sheet grammar.pegjs"
+    "build-parser": "pegjs --allowed-start-rules expression,sheet grammar.pegjs",
+    "test-perf": "node --expose-gc perf/index.js"
   }
 }

--- a/perf/index.js
+++ b/perf/index.js
@@ -1,0 +1,59 @@
+var assert = require("assert");
+var memwatch = require("memwatch");
+
+var Bindings = require("../bindings");
+
+var SIZE = 10000;
+var TIMES = 10;
+
+var makeRandomArray = function(n) {
+    var res = [];
+    for (var i=0; i<n; i++){
+        res.push(Math.floor(Math.random()*100000));
+    }
+    return res;
+};
+
+var observeArray = {
+    frb: function() {
+        var bound = Bindings.defineBindings({
+            array: makeRandomArray(SIZE)
+        }, {
+            sumOfOdds: {"<-": "array.filter{%2}.sum()"}
+        });
+        var r = bound.sumOfOdds;
+        bound.array.push(11);
+        assert(r+11 === bound.sumOfOdds, "FRB logic failed");
+        Bindings.cancelBindings(bound);
+    },
+
+    naive: function() {
+        var array = makeRandomArray(SIZE);
+        var sumOfOdds = function(){
+            return array.filter(function(x){ return x % 2 == 1; }).reduce(function(a, b){ return a+b; });
+        };
+        var r = sumOfOdds();
+        array.push(11);
+        assert(r+11 === sumOfOdds(), "Naive logic failed");
+    }
+};
+
+var test = function(callback) {
+    global.gc();
+    var start = new Date();
+    var hd = new memwatch.HeapDiff();
+
+    for(var i=0; i<TIMES; i++) callback();
+    global.gc();
+
+    var res = hd.end();
+    res.time = new Date() - start;
+    return res;
+};
+
+var compare = function() {
+    console.log("FRB", JSON.stringify(test(observeArray.frb), null, 4));
+    console.log("Naive", JSON.stringify(test(observeArray.naive), null, 4));
+};
+
+compare();


### PR DESCRIPTION
:warning: This is work-in-progress, not ready to merge.

I started writing simple FRB benchmarks. This one seems to show that we're leaking an array. The memory leaked works out consistently to a not-coincidental ~32bytes per item in the input array. 

What should sensible output from these be? Actual numbers, or perhaps a limit on space/time and then each test either passes or fails?

Here's the current, very verbose, output:

```
FRB {
    "before": {
        "nodes": 23165,
        "time": "2013-10-15T15:35:18.000Z",
        "size_bytes": 3215944,
        "size": "3.07 mb"
    },
    "after": {
        "nodes": 24073,
        "time": "2013-10-15T15:35:21.000Z",
        "size_bytes": 3628504,
        "size": "3.46 mb"
    },
    "change": {
        "size_bytes": 412560,
        "size": "402.89 kb",
        "freed_nodes": 2726,
        "allocated_nodes": 3634,
        "details": [
            {
                "what": "Array",
                "size_bytes": 318400,
                "size": "310.94 kb",
                "+": 1588,
                "-": 1186
            },
            {
                "what": "Code",
                "size_bytes": 77104,
                "size": "75.3 kb",
                "+": 752,
                "-": 751
            },
            {
                "what": "Dict",
                "size_bytes": 192,
                "size": "192 bytes",
                "+": 4,
                "-": 0
            },
            {
                "what": "Number",
                "size_bytes": 80,
                "size": "80 bytes",
                "+": 5,
                "-": 0
            },
            {
                "what": "Object",
                "size_bytes": 1840,
                "size": "1.8 kb",
                "+": 46,
                "-": 0
            },
            {
                "what": "RegExp",
                "size_bytes": 792,
                "size": "792 bytes",
                "+": 11,
                "-": 0
            },
            {
                "what": "Scope",
                "size_bytes": 128,
                "size": "128 bytes",
                "+": 2,
                "-": 0
            },
            {
                "what": "String",
                "size_bytes": 13272,
                "size": "12.96 kb",
                "+": 619,
                "-": 195
            }
        ]
    },
    "time": 3366
}
Naive {
    "before": {
        "nodes": 22375,
        "time": "2013-10-15T15:35:21.000Z",
        "size_bytes": 3605136,
        "size": "3.44 mb"
    },
    "after": {
        "nodes": 22260,
        "time": "2013-10-15T15:35:21.000Z",
        "size_bytes": 3597840,
        "size": "3.43 mb"
    },
    "change": {
        "size_bytes": -7296,
        "size": "-7.13 kb",
        "freed_nodes": 182,
        "allocated_nodes": 69,
        "details": [
            {
                "what": "Array",
                "size_bytes": 3840,
                "size": "3.75 kb",
                "+": 34,
                "-": 51
            },
            {
                "what": "Code",
                "size_bytes": -6464,
                "size": "-6.31 kb",
                "+": 17,
                "-": 34
            },
            {
                "what": "String",
                "size_bytes": -896,
                "size": "-896 bytes",
                "+": 2,
                "-": 22
            }
        ]
    },
    "time": 130
}
```
