### PR TITLE
Add min() and max() functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,8 +499,8 @@ value of the collection.
 
 ```javascript
 var object = Bindings.defineBindings({}, {
-    min: {"<-": "values.min{}"},
-    max: {"<-": "values.max{}"}
+    min: {"<-": "values.min()"},
+    max: {"<-": "values.max()"}
 });
 
 expect(object.min).toBe(undefined);
@@ -509,6 +509,9 @@ expect(object.max).toBe(undefined);
 object.values = [2, 3, 2, 1, 2];
 expect(object.min).toBe(1);
 expect(object.max).toBe(3);
+
+object.values.push(4);
+expect(object.max).toBe(4);
 ```
 
 Min and max blocks accept an expression on which to compare values from

--- a/compile-observer.js
+++ b/compile-observer.js
@@ -38,6 +38,8 @@ var semantics = compile.semantics = {
         groupMapBlock: Observers.makeGroupMapBlockObserver,
         minBlock: Observers.makeMinBlockObserver,
         maxBlock: Observers.makeMaxBlockObserver,
+        min: Observers.makeMinObserver,
+        max: Observers.makeMaxObserver,
         enumerate: Observers.makeEnumerationObserver,
         reversed: Observers.makeReversedObserver,
         flatten: Observers.makeFlattenObserver,

--- a/observers.js
+++ b/observers.js
@@ -767,6 +767,16 @@ function makeMinBlockObserver(observeCollection, observeRelation) {
     return makeHeapBlockObserver(observeCollection, observeRelation, -1);
 }
 
+exports.makeMaxObserver = makeMaxObserver;
+function makeMaxObserver(observeCollection) {
+    return makeHeapBlockObserver(observeCollection, observeValue, 1);
+}
+
+exports.makeMinObserver = makeMinObserver;
+function makeMinObserver(observeCollection) {
+    return makeHeapBlockObserver(observeCollection, observeValue, -1);
+}
+
 // used by both some and every blocks
 var observeLengthLiteral = makeLiteralObserver("length");
 

--- a/spec/readme-spec.js
+++ b/spec/readme-spec.js
@@ -322,8 +322,8 @@ describe("Tutorial", function () {
 
     it("Min and Max", function () {
         var object = Bindings.defineBindings({}, {
-            min: {"<-": "values.min{}"},
-            max: {"<-": "values.max{}"}
+            min: {"<-": "values.min()"},
+            max: {"<-": "values.max()"}
         });
 
         expect(object.min).toBe(undefined);
@@ -332,6 +332,9 @@ describe("Tutorial", function () {
         object.values = [2, 3, 2, 1, 2];
         expect(object.min).toBe(1);
         expect(object.max).toBe(3);
+
+        object.values.push(4);
+        expect(object.max).toBe(4);
     });
 
     it("Min and Max (by property)", function () {


### PR DESCRIPTION
These supplement the already existing min{} and max{} blocks, for the
case where the value to compare is itself.  Both syntaxes work for this
case now.  Previously, these would fall back to the subtle failure of
using collection's non-reactive implementation of `min` or `max`.
