### PR TITLE
Get turns to delete for undefined values

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,6 +915,35 @@ object.key = a; // no effect
 expect(object.selected).toBe(40);
 ```
 
+If a `get` function call appears on the target side of a binding, the
+expression as a whole becomes a `set` or `delete` binding.  The name of
+the function does not change to `set` because the expression may be used
+as both a source and target if the binding is bidirectional.  If the
+bound value is `null` or `undefined`, the binding will delete whatever
+value exists for the observed key.
+
+```javascript
+var Dict = require("collections/dict");
+var object = Bindings.defineBindings({
+    dict: new Dict({a: 10}),
+    key: "a"
+}, {
+    "dict.get(key)": {"<->": "value"}
+});
+
+expect(object.dict.has("a")).toBe(false);
+
+object.value = 10;
+expect(object.dict.get("a")).toBe(10);
+
+object.dict.set("a", 20);
+expect(object.value).toBe(20);
+
+object.key = "b";
+expect(object.dict.get("a")).toBe(10);
+expect(object.dict.get("b")).toBe(20);
+```
+
 You can also bind the entire content of a map-like collection to the
 content of another.  Bear in mind that the content of the source
 replaces the content of the target initially.

--- a/spec/readme-spec.js
+++ b/spec/readme-spec.js
@@ -598,6 +598,28 @@ describe("Tutorial", function () {
         expect(object.selected).toBe(40);
     });
 
+    it("Get (Bind)", function () {
+        var Dict = require("collections/dict");
+        var object = Bindings.defineBindings({
+            dict: new Dict({a: 10}),
+            key: "a"
+        }, {
+            "dict.get(key)": {"<->": "value"}
+        });
+
+        expect(object.dict.has("a")).toBe(false);
+
+        object.value = 10;
+        expect(object.dict.get("a")).toBe(10);
+
+        object.dict.set("a", 20);
+        expect(object.value).toBe(20);
+
+        object.key = "b";
+        expect(object.dict.get("a")).toBe(10);
+        expect(object.dict.get("b")).toBe(20);
+    });
+
     it("Get (all content)", function () {
         var Map = require("collections/map");
         var object = {


### PR DESCRIPTION
Previously, get would always set on the target side.  Now, it will
delete if the value is null or undefined.  These behaviors of "get" are
now documented.

This also introduces restorative cancelation on bindings.  That is, if a
binding is canceled, the bound collection will be restored to the state
before the binding was applied.  This makes it possible for a get
binding to be gracefully moved to a different key, without "painting"
the corresponding value over all the keys it visits, and allows a "has"
binding to remove a value that it introduced when the binding is
relaxed.  This is particularly useful for the case of a child that
maintains its presence in its parent's children collection until its
bindings are canceled.
