### PR TITLE
Fix inconsistency in ?: between evaluate & observe

### DIFF
--- a/compile-evaluator.js
+++ b/compile-evaluator.js
@@ -184,7 +184,9 @@ var argCompilers = {
 
     "if": function (evaluateCondition, evaluateConsequent, evaluateAlternate) {
         return function (scope) {
-            if (evaluateCondition(scope)) {
+            var condition = evaluateCondition(scope);
+            if (condition == null) return;
+            if (condition) {
                 return evaluateConsequent(scope);
             } else {
                 return evaluateAlternate(scope);

--- a/spec/evaluate.js
+++ b/spec/evaluate.js
@@ -664,6 +664,24 @@ module.exports = [
             }
         },
         output: true
+    },
+
+    {
+        path: "isAdmin ? 'admin' : 'user'",
+        input: {},
+        output: undefined
+    },
+
+    {
+        path: "isAdmin ? 'admin' : 'user'",
+        input: {isAdmin: true},
+        output: 'admin'
+    },
+
+    {
+        path: "isAdmin ? 'admin' : 'user'",
+        input: {isAdmin: false},
+        output: 'user'
     }
 
 ];


### PR DESCRIPTION
Fixes an inconsistency in the ternary conditional operator, symbolically
`?:` and named "if" internally, between the implementation of evaluate
and observe. With this change, binders, assigners, evaluators, and
observers all consider a null or undefined input indicative of an
undefined output, rather than interpreting the input as false.
