### PR TITLE
Fix null cases for string contains operators

### DIFF
--- a/observers.js
+++ b/observers.js
@@ -1042,8 +1042,12 @@ exports.makeStartsWithObserver = makeStartsWithObserver;
 function makeStartsWithObserver(observeHaystack, observeNeedle) {
     return function observeStartsWith(emit, scope) {
         return observeNeedle(function (needle) {
+            if (typeof needle !== "string")
+                return emit();
             var expression = new RegExp("^" + RegExp.escape(needle));
             return observeHaystack(function (haystack) {
+                if (typeof haystack !== "string")
+                    return emit();
                 return emit(expression.test(haystack));
             }, scope);
         }, scope);
@@ -1054,8 +1058,12 @@ exports.makeEndsWithObserver = makeEndsWithObserver;
 function makeEndsWithObserver(observeHaystack, observeNeedle) {
     return function observeEndsWith(emit, scope) {
         return observeNeedle(function (needle) {
+            if (typeof needle !== "string")
+                return emit();
             var expression = new RegExp(RegExp.escape(needle) + "$");
             return observeHaystack(function (haystack) {
+                if (typeof haystack !== "string")
+                    return emit();
                 return emit(expression.test(haystack));
             }, scope);
         }, scope);
@@ -1066,8 +1074,12 @@ exports.makeContainsObserver = makeContainsObserver;
 function makeContainsObserver(observeHaystack, observeNeedle) {
     return function observeContains(emit, scope) {
         return observeNeedle(function (needle) {
+            if (typeof needle !== "string")
+                return emit();
             var expression = new RegExp(RegExp.escape(needle));
             return observeHaystack(function (haystack) {
+                if (typeof haystack !== "string")
+                    return emit();
                 return emit(expression.test(haystack));
             }, scope);
         }, scope);

--- a/spec/evaluate.js
+++ b/spec/evaluate.js
@@ -497,6 +497,33 @@ module.exports = [
     },
 
     {
+        path: "x.startsWith(y)",
+        input: {
+            x: undefined,
+            y: undefined
+        },
+        output: undefined
+    },
+
+    {
+        path: "x.startsWith(y)",
+        input: {
+            x: "",
+            y: undefined
+        },
+        output: undefined
+    },
+
+    {
+        path: "x.startsWith(y)",
+        input: {
+            x: undefined,
+            y: ""
+        },
+        output: undefined
+    },
+
+    {
         path: "x.endsWith(y)",
         input: {
             x: "|.!",
@@ -515,6 +542,60 @@ module.exports = [
     },
 
     {
+        path: "x.endsWith(y)",
+        input: {
+            x: undefined,
+            y: undefined
+        },
+        output: undefined
+    },
+
+    {
+        path: "x.endsWith(y)",
+        input: {
+            x: "",
+            y: undefined
+        },
+        output: undefined
+    },
+
+    {
+        path: "x.endsWith(y)",
+        input: {
+            x: undefined,
+            y: ""
+        },
+        output: undefined
+    },
+
+    {
+        path: "x.contains(y)",
+        input: {
+            x: undefined,
+            y: undefined
+        },
+        output: undefined
+    },
+
+    {
+        path: "x.contains(y)",
+        input: {
+            x: "",
+            y: undefined
+        },
+        output: undefined
+    },
+
+    {
+        path: "x.contains(y)",
+        input: {
+            x: undefined,
+            y: ""
+        },
+        output: undefined
+    },
+
+    {
         path: "&contains(x, y)",
         input: {
             x: "?!^*",
@@ -530,6 +611,12 @@ module.exports = [
     },
 
     {
+        path: "join()",
+        input: null,
+        output: undefined
+    },
+
+    {
         path: "split()",
         input: "abc",
         output: ['a', 'b', 'c']
@@ -539,6 +626,12 @@ module.exports = [
         path: "split(', ')",
         input: "a, b, c",
         output: ['a', 'b', 'c']
+    },
+
+    {
+        path: "split()",
+        input: null,
+        output: undefined
     },
 
     {


### PR DESCRIPTION
Previously, startsWith, endsWith, and contains observers would throw an
exception if the input was undefined.
