### PR TITLE
Alterations to object by label observers

### DIFF
--- a/observers.js
+++ b/observers.js
@@ -43,13 +43,14 @@ function makeElementObserver(id) {
 exports.makeComponentObserver = makeComponentObserver;
 function makeComponentObserver(label, syntax) {
     return function observeComponent(emit, scope) {
-        // TODO error if scope.components does not exist or components for
-        // label does not exist
         var components = scope.components;
-        var method = components.getObjectByLabel || components.getComponentByLabel;
-        var component = method.call(components, label);
-        syntax.component = component;
-        return emit(component);
+        if (components && typeof components.observeObjectByLabel === "function") {
+            return components.observeObjectByLabel(label, emit, scope);
+        } else if (components && typeof components.getObjectByLabel === "function") {
+            return emit(components.getObjectByLabel(label));
+        } else {
+            return emit();
+        }
     };
 }
 

--- a/spec/expand-spec.js
+++ b/spec/expand-spec.js
@@ -73,36 +73,5 @@ describe("expand", function () {
         });
     });
 
-
-    it("should expand component labels from a serializer", function () {
-
-        var syntax = parse("@a");
-        var a = {};
-        var observe = compileObserver(syntax);
-        var scope = new Scope();
-        scope.components = {
-            getObjectByLabel: function (label) {
-                expect(label).toBe("a");
-                return a;
-            }
-        };
-        var cancel = observe(function (_a) {
-            expect(_a).toBe(a);
-        }, scope);
-
-        expect(syntax.component).toBe(a);
-
-        var scope = new Scope();
-        scope.components = {
-            getObjectLabel: function (_a) {
-                expect(_a).toBe(a);
-                return "b";
-            },
-        };
-        var syntax = expand(syntax, scope);
-        expect(stringify(syntax)).toBe("@b");
-
-    });
-
 });
 


### PR DESCRIPTION
1. Removes support for annotating the syntax tree with the last known
   object to be observed for a label on that node. This is necessary for
   syntax tree memoization. This also breaks a few Montage test cases that
   may or may not be important: `serialization-spec` localizations unit
   serializer serializes default message binding, and serializes data
   binding, as well as `bindings-spec` should serialize a binding that
   references external objects.
2. Adds support for `observeObjectByLabel` that has been useful in
   experiments where the object in scope may change in response to panel
   changes in a substitution.
3. Removes the alias `getComponentByLabel` because, in the context of
   Montage serialization, labels may be applied to any value.
