### PR TITLE
Treat null, undefined, and NaN as viral contaigons

### DIFF
--- a/observers.js
+++ b/observers.js
@@ -326,7 +326,7 @@ exports.makeDefinedObserver = makeDefinedObserver;
 function makeDefinedObserver(observeValue) {
     return function observeDefault(emit, scope) {
         return observeValue(autoCancelPrevious(function replaceValue(value) {
-            return emit(value != null);
+            return emit(Operators.defined(value));
         }), scope);
     };
 }

--- a/operators.js
+++ b/operators.js
@@ -111,7 +111,9 @@ exports.or = function (a, b) {
 };
 
 exports.defined = function (value) {
-    return value != null;
+    // value != null eliminates null and undefined
+    // value === value eliminates NaN
+    return value != null && value === value;
 };
 
 // "startsWith", "endsWith", and "contains"  are overridden in


### PR DESCRIPTION
This adds NaN to the list of invalid inputs for operators, such that
they will all propagate as undefined.
